### PR TITLE
Housekeeping after first stable release

### DIFF
--- a/cmd/watcher/main.go
+++ b/cmd/watcher/main.go
@@ -21,14 +21,14 @@ func main() {
 	flag.Parse()
 
 	baseDir := *dir
-	ignoredExtensions := []string{".swp"}
 
 	if !filepath.IsAbs(baseDir) {
 		log.Fatal("dir argument must be an absolute path, like /usr/local/nagios/etc/")
 	}
 
-	files, directories, err := watcher.GetAllInDirectory(baseDir, ignoredExtensions)
+	ignoredExtensions := []string{".swp"}
 
+	files, directories, err := watcher.GetAllInDirectory(baseDir, ignoredExtensions)
 	if err != nil {
 		log.Fatalf("GetAllInDirectory: %v", err)
 	}
@@ -37,6 +37,8 @@ func main() {
 	if err != nil {
 		log.Fatalf("NewDifferential: %v", err)
 	}
+
+	log.Printf("Initialized Differential watcher with %d files and %d directories", len(files), len(directories))
 
 	done := make(chan struct{})
 

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/google/go-cmp/cmp"
@@ -172,6 +173,11 @@ func (d Differential) WatchFn(path string) error {
 	if _, ok := d.ignoredExtensions[filepath.Ext(path)]; ok {
 		return nil
 	}
+
+	// This is to allow for changes to propagate on the filesystem. If the file
+	// is large, the write won't be atomic. It will happen in, for example, 4096
+	// bytes chunks. 1 ms should be enough.
+	time.Sleep(time.Millisecond)
 
 	contents, err := ioutil.ReadFile(path)
 	if err != nil {

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -29,7 +29,10 @@ func getIgnoredExtensions(extensions []string) map[string]struct{} {
 // GetAllInDirectory recursively returns all paths to files and directories in
 // dir (excluding files with ignored extensions). It returns nil, nil, <err> on
 // the first error encountered.
-func GetAllInDirectory(dir string, ignoredExtensions []string) ([]string, []string, error) {
+func GetAllInDirectory(dir string, ignoredExtensions []string) (
+	[]string,
+	[]string,
+	error) {
 	var files, directories []string
 
 	ignoredExtensionsLookup := getIgnoredExtensions(ignoredExtensions)

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -81,16 +81,16 @@ func (p *Plugin) setConfiguration(configuration *configuration) {
 	p.configuration = configuration
 }
 
-// OnConfigurationChange is invoked when configuration changes may have been made.
+// OnConfigurationChange is invoked when configuration changes may have been
+// made.
 func (p *Plugin) OnConfigurationChange() error {
 	var configuration = new(configuration)
 
-	// Load the public configuration fields from the Mattermost server configuration.
+	// Load the public configuration fields from the Mattermost server
+	// configuration.
 	if err := p.API.LoadPluginConfiguration(configuration); err != nil {
 		return errors.Wrap(err, "failed to load plugin configuration")
 	}
-
-	p.setConfiguration(configuration)
 
 	config := p.getConfiguration()
 
@@ -104,6 +104,10 @@ func (p *Plugin) OnConfigurationChange() error {
 	}
 
 	p.client = c
+
+	p.setConfiguration(configuration)
+
+	p.API.LogInfo("Reloaded configuration")
 
 	return nil
 }

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -92,6 +92,8 @@ func (p *Plugin) OnConfigurationChange() error {
 		return errors.Wrap(err, "failed to load plugin configuration")
 	}
 
+	p.setConfiguration(configuration)
+
 	config := p.getConfiguration()
 
 	if err := config.isValid(); err != nil {
@@ -104,8 +106,6 @@ func (p *Plugin) OnConfigurationChange() error {
 	}
 
 	p.client = c
-
-	p.setConfiguration(configuration)
 
 	p.API.LogInfo("Reloaded configuration")
 

--- a/server/main.go
+++ b/server/main.go
@@ -13,7 +13,6 @@ func main() {
 			setReportFrequencyKey: setReportFrequency,
 			subscribeKey:          subscribe,
 			unsubscribeKey:        unsubscribe,
-			// TODO: add `help`?
 		},
 	})
 }

--- a/server/report.go
+++ b/server/report.go
@@ -377,7 +377,7 @@ func (p *Plugin) monitoringReportLoop() {
 			continue
 		}
 
-		p.API.LogDebug("Acquired lock", "id", p.API.GetDiagnosticId())
+		p.API.LogDebug("monitoringReportLoop: acquired lock", "id", p.API.GetDiagnosticId())
 
 		c, err := getReportChannel(p.API)
 		if err != nil {
@@ -386,6 +386,7 @@ func (p *Plugin) monitoringReportLoop() {
 		}
 
 		if c == "" { // fast path, there is no subscription.
+			p.API.LogDebug("monitoringReportLoop: no subscription")
 			continue
 		}
 

--- a/server/watcher.go
+++ b/server/watcher.go
@@ -19,8 +19,8 @@ func formatChange(change watcher.Change) string {
 
 	b.WriteString("```diff\n")
 
-	if len(change.Diff)+b.Len()+3 > model.POST_MESSAGE_MAX_BYTES_V2 {
-		b.WriteString("File has been changed, but the diff is too long.")
+	if len(change.Diff)+b.Len()+3 > model.POST_MESSAGE_MAX_RUNES_V1*4 {
+		b.WriteString("File has been changed, but the diff is too long.\n")
 	} else {
 		b.WriteString(change.Diff)
 	}
@@ -46,7 +46,7 @@ func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Req
 	}
 
 	if token != r.Header.Get(watcher.TokenHeader) {
-		p.API.LogWarn("Changes handler called, but authentication failed")
+		p.API.LogWarn("Changes handler called, but authentication failed", "ctx", c)
 		http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 
 		return

--- a/server/watcher.go
+++ b/server/watcher.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"unicode/utf8"
 
 	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/mattermost/mattermost-server/v5/plugin"
@@ -20,8 +19,7 @@ func formatChange(change watcher.Change) string {
 
 	b.WriteString("```diff\n")
 
-	// TODO(amwolff): update the threshold (it's lower now).
-	if utf8.RuneCountInString(change.Diff) > 16077 {
+	if len(change.Diff)+b.Len()+3 > model.POST_MESSAGE_MAX_BYTES_V2 {
 		b.WriteString("File has been changed, but the diff is too long.")
 	} else {
 		b.WriteString(change.Diff)


### PR DESCRIPTION
- calculate `formatChange` threshold properly;
- improve logging;
- fix long lines;
- improve `internal/watcher` tests.